### PR TITLE
ci(workflows/deploy): use `prod` as production branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - dev
+      - prod
   pull_request: {}
 
 permissions:
@@ -127,7 +127,7 @@ jobs:
   build:
     name: Build
     # only build/deploy main branch on pushes
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/prod') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, vitest, cypress, build]
     # only build/deploy main branch on pushes
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/prod') && github.event_name == 'push' }}
 
     steps:
       - name: Cancel Previous Runs
@@ -205,7 +205,7 @@ jobs:
           field: 'app'
 
       - name: Deploy Staging
-        if: ${{ github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: superfly/flyctl-actions@1.3
         with:
           args: 'deploy --app ${{ steps.app_name.outputs.value }}-staging --image registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}'
@@ -213,7 +213,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Deploy Production
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/prod' }}
         uses: superfly/flyctl-actions@1.3
         with:
           args: 'deploy --image registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}'


### PR DESCRIPTION
This commit removes the `dev` branch and instead marks `main` as the development branch while `prod` is the production branch. This change is purely aesthetic and was made primarily just to maintain consistency with what I'm having to do at work (so my workflows remains the same and I don't have to context switch as much).