### PR TITLE
perf: don't optimize images to reduce compute costs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
+# feature flags
+OPTIMIZE_IMAGES="false"
+
+# configuration
 DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres"
 SESSION_SECRET="super-duper-s3cret"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ Prior to your first deployment, you'll need to do a few things:
 
 - Add a `FLY_API_TOKEN` to your GitHub repo. To do this, go to your user settings on Fly and create a new [token](https://web.fly.io/user/personal_access_tokens/new), then add it to [your repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) with the name `FLY_API_TOKEN`.
 
+- Specify the `OPTIMIZE_IMAGES` feature flag, to do this you can run the following commands:
+
+  ```sh
+  fly secrets set OPTIMIZE_IMAGES=true --app nicholas-eng
+  fly secrets set OPTIMIZE_IMAGES=false --app nicholas-eng-staging
+  ```
+
+  > **Note:** Enabling this feature flag will dramatically increase CPU/RAM load; your application may OOM and you may incur unexpectedly high compute costs (~$100 for two `shared-cpu-1x` on Fly.io for the additional RAM, shared CPU seconds, and SSD storage required for image optimization).
+  >
+  > It is recommended to disable this flag in staging and only enable it in production if your deployment target supports it (e.g. you'll probably want to scale up from `shared-cpu-1x` to prevent OOMs) and you are willing to pay the extra compute costs for the slight performance boost to the end-user.
+
 - Add a `SESSION_SECRET` to your fly app secrets, to do this you can run the following commands:
 
   ```sh

--- a/app/image.server.ts
+++ b/app/image.server.ts
@@ -42,6 +42,12 @@ export const loader: LoaderFunction = async ({ request }) => {
   if (!src) return badImageResponse()
   log.debug('optimizing image... %s', src)
 
+  if (process.env.OPTIMIZE_IMAGES === 'false') {
+    const { href } = new URL(src, request.url)
+    log.warn('skipping optimized image due to feature flag... %s', href)
+    return fetch(href, request)
+  }
+
   const width = getIntOrNull(url.searchParams.get('width'))
   const height = getIntOrNull(url.searchParams.get('height'))
   const fit = (url.searchParams.get('fit') as keyof FitEnum) || 'cover'


### PR DESCRIPTION
This commit adds an `OPTIMIZE_IMAGES` feature flag that, when set to false, will cause the image optimization API route to skip any image optimizations and simply fetch the requested image URL.

This change was introduced to save Fly.io compute costs while still under development (and to reduce CPU and memory load on the shared instance to prevent unnecessary OOMs).

Blocked by: #8 