### PR TITLE
perf(routes): use `vercel` edge functions

### DIFF
--- a/app/routes/__layout.tsx
+++ b/app/routes/__layout.tsx
@@ -5,6 +5,8 @@ import * as Header from 'components/header'
 
 import { log } from 'log.server'
 
+export const config = { runtime: 'edge' }
+
 export function loader() {
   // the ui knows what type of filter select ux to show based on the field type:
   //

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -9,65 +9,7 @@ import { Link } from '@remix-run/react'
 
 import { ThemeSwitcher } from 'components/theme-switcher'
 
-const DATE_FORMAT: Intl.DateTimeFormatOptions = {
-  month: 'numeric',
-  year: 'numeric',
-}
-
-interface MilestoneProps {
-  start: Date
-  end?: Date
-  title: string
-  subtitle: string
-  url?: string
-  icon?: FunctionComponent<IconProps>
-  openInNew?: boolean
-}
-
-function Milestone({
-  start,
-  end,
-  title,
-  subtitle,
-  url,
-  icon,
-  openInNew,
-}: MilestoneProps) {
-  const Icon = icon ?? ArrowTopRightIcon
-  return (
-    <article className='before:content-[" "] relative m-12 text-lg leading-none before:absolute before:-left-6.5 before:top-1/2 before:h-1 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-gray-300 after:absolute after:-left-[calc(1.5rem_+_0.5px)] after:top-1/2 after:h-[calc(100%_+_3rem)] after:border-l after:border-gray-300 last:after:hidden dark:before:bg-gray-100 dark:after:border-gray-100'>
-      <p className='text-xs lowercase text-gray-900/50 dark:text-gray-100/50'>
-        {start.toLocaleString(undefined, DATE_FORMAT)}
-        {end ? `–${end.toLocaleString(undefined, DATE_FORMAT)}` : ''}
-      </p>
-      <h1 className='my-2 font-semibold'>
-        {!url && title}
-        {url && !openInNew && (
-          <Link
-            to={url}
-            prefetch='intent'
-            className='items-top link group flex underline'
-          >
-            {title}
-            <Icon className='ml-1 inline-block h-4 w-4 text-gray-400 dark:text-gray-500' />
-          </Link>
-        )}
-        {url && openInNew && (
-          <a
-            href={url}
-            target='_blank'
-            rel='noopener noreferrer'
-            className='items-top link group flex underline'
-          >
-            {title}
-            <Icon className='ml-1 inline-block h-4 w-4 text-gray-400 dark:text-gray-500' />
-          </a>
-        )}
-      </h1>
-      <h2>{subtitle}</h2>
-    </article>
-  )
-}
+export const config = { runtime: 'edge' }
 
 export default function IndexPage() {
   return (
@@ -139,5 +81,65 @@ export default function IndexPage() {
         />
       </section>
     </main>
+  )
+}
+
+const DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: 'numeric',
+  year: 'numeric',
+}
+
+interface MilestoneProps {
+  start: Date
+  end?: Date
+  title: string
+  subtitle: string
+  url?: string
+  icon?: FunctionComponent<IconProps>
+  openInNew?: boolean
+}
+
+function Milestone({
+  start,
+  end,
+  title,
+  subtitle,
+  url,
+  icon,
+  openInNew,
+}: MilestoneProps) {
+  const Icon = icon ?? ArrowTopRightIcon
+  return (
+    <article className='before:content-[" "] relative m-12 text-lg leading-none before:absolute before:-left-6.5 before:top-1/2 before:h-1 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-gray-300 after:absolute after:-left-[calc(1.5rem_+_0.5px)] after:top-1/2 after:h-[calc(100%_+_3rem)] after:border-l after:border-gray-300 last:after:hidden dark:before:bg-gray-100 dark:after:border-gray-100'>
+      <p className='text-xs lowercase text-gray-900/50 dark:text-gray-100/50'>
+        {start.toLocaleString(undefined, DATE_FORMAT)}
+        {end ? `–${end.toLocaleString(undefined, DATE_FORMAT)}` : ''}
+      </p>
+      <h1 className='my-2 font-semibold'>
+        {!url && title}
+        {url && !openInNew && (
+          <Link
+            to={url}
+            prefetch='intent'
+            className='items-top link group flex underline'
+          >
+            {title}
+            <Icon className='ml-1 inline-block h-4 w-4 text-gray-400 dark:text-gray-500' />
+          </Link>
+        )}
+        {url && openInNew && (
+          <a
+            href={url}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='items-top link group flex underline'
+          >
+            {title}
+            <Icon className='ml-1 inline-block h-4 w-4 text-gray-400 dark:text-gray-500' />
+          </a>
+        )}
+      </h1>
+      <h2>{subtitle}</h2>
+    </article>
   )
 }

--- a/app/routes/join.tsx
+++ b/app/routes/join.tsx
@@ -8,6 +8,8 @@ import { createUser, getUserByEmail } from 'models/user.server'
 import { createUserSession, getUserId } from 'session.server'
 import { safeRedirect, validateEmail, validateUsername } from 'utils'
 
+export const config = { runtime: 'edge' }
+
 export async function loader({ request }: LoaderArgs) {
   const userId = await getUserId(request)
   if (userId) return redirect('/')

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -8,6 +8,8 @@ import { verifyLogin } from 'models/user.server'
 import { createUserSession, getUserId } from 'session.server'
 import { safeRedirect, validateEmail } from 'utils'
 
+export const config = { runtime: 'edge' }
+
 export async function loader({ request }: LoaderArgs) {
   const userId = await getUserId(request)
   if (userId) return redirect('/')

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -3,6 +3,8 @@ import { redirect } from '@vercel/remix'
 
 import { logout } from 'session.server'
 
+export const config = { runtime: 'edge' }
+
 export async function action({ request }: ActionArgs) {
   return logout(request)
 }


### PR DESCRIPTION
This patch updates most of my routes to use Vercel edge functions (which are a wrapper over Cloudflare Workers [1]) by exporting a config object that is consumed by the Vercel build API [2].

[1]: https://vercel.com/docs/concepts/functions/edge-functions/limitations
[2]: https://vercel.com/docs/frameworks/remix#edge-functions