### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,7 +11,7 @@
       }
     ],
     [
-      "@google/semantic-release-replace-plugin",
+      "semantic-release-replace-plugin",
       {
         "replacements": [
           {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@google/semantic-release-replace-plugin": "^1.2.0",
+    "semantic-release-replace-plugin": "^1.2.0",
     "@remix-run/dev": "^1.17.1",
     "@remix-run/eslint-config": "^1.17.1",
     "@remix-run/serve": "^1.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2545,7 +2545,7 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@google/semantic-release-replace-plugin@1.2.0:
+  /semantic-release-replace-plugin@1.2.0:
     resolution: {integrity: sha512-ucZHG4eOtWjW+mSD3GSHg/LKyqY4N5KYk/QYpWD580FDE7eii0fmns9v0jpbsDj8W+pV7QXmbSDqIpPVfBrptg==}
     dependencies:
       jest-diff: 26.6.2


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).