### PR TITLE
fix(routes/show): always show accurate review count

### DIFF
--- a/app/routes/_layout.shows.$showId.tsx
+++ b/app/routes/_layout.shows.$showId.tsx
@@ -211,7 +211,7 @@ function Score({ value, label, count }: ScoreProps) {
         </h2>
         <p className='text-xs font-semibold uppercase'>{label}</p>
         <p className='text-xs'>
-          {value == null ? 'No Reviews' : `${count} Reviews`}
+          {count === 0 ? 'No Reviews' : `${count} Reviews`}
         </p>
       </div>
     </li>


### PR DESCRIPTION
This patch updates the score displays to show the accurate review counts even if there isn't a score assigned to them.