### PR TITLE
feat(routes/shows): set look image aspect ratio

### DIFF
--- a/app/routes/_layout.shows.$showId.tsx
+++ b/app/routes/_layout.shows.$showId.tsx
@@ -54,8 +54,12 @@ function About({ className }: { className: string }) {
           Download the <a href={show.video.url}>MP4</a> video.
         </video>
         <div className='flex gap-2'>
-          <div className='flex-none w-40 bg-gray-100 dark:bg-gray-800 flex items-center justify-center overflow-hidden'>
-            <img src={show.looks[0].image.url} alt='' />
+          <div className='flex-none w-40 bg-gray-100 dark:bg-gray-800'>
+            <img
+              className='object-cover h-full'
+              src={show.looks[0].image.url}
+              alt=''
+            />
           </div>
           <article className='flex-1 bg-gray-100 dark:bg-gray-800 text-center px-6 flex flex-col'>
             <h1 className='font-serif font-bold text-5xl mb-1 mt-8'>
@@ -136,7 +140,13 @@ function Looks({ className }: { className: string }) {
       <ol className='grid grid-cols-2 gap-x-2 gap-y-6'>
         {show.looks.map((look) => (
           <li key={look.id}>
-            <img src={look.image.url} alt={`Look ${look.number}`} />
+            <div className='bg-gray-100 dark:bg-gray-800 aspect-person'>
+              <img
+                className='object-cover h-full'
+                src={look.image.url}
+                alt=''
+              />
+            </div>
             <p className='mt-0.5 text-sm'>Look {look.number}</p>
           </li>
         ))}

--- a/app/routes/_layout.shows._index.tsx
+++ b/app/routes/_layout.shows._index.tsx
@@ -29,7 +29,13 @@ export default function ShowsPage() {
           {shows.map((show) => (
             <li key={show.id}>
               <Link to={`/shows/${show.id}`} className='text-center'>
-                <img className='mb-2' src={show.looks[0].image.url} alt='' />
+                <div className='bg-gray-100 dark:bg-gray-800 aspect-person mb-2'>
+                  <img
+                    className='object-cover h-full'
+                    src={show.looks[0].image.url}
+                    alt=''
+                  />
+                </div>
                 <h2 className='text-xl font-serif font-semibold'>
                   {show.brands.map((brand) => brand.name).join(', ')}
                 </h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,6 +44,9 @@ module.exports = {
       ],
     },
     extend: {
+      aspectRatio: {
+        person: '9 / 16',
+      },
       fontSize: {
         'xs': ['0.8125rem', '1.0625rem'],
         '2xs': ['0.75rem', '1rem'],


### PR DESCRIPTION
This patch sets a fixed look image aspect ratio (9 / 16) to avoid layout shift and to ensure that the "shows" grid has consistent image sizes. I may decide to revert this change for the "looks" grid in the actual show page (as designers may have an artistic choice in framing their look photos), but for now, this works elegantly.

This change was inspired by the fixed ratio images used in the Vogue Runway list of shows [[1]].

[1]: https://www.vogue.com/fashion-shows