### PR TITLE
fix(routes/show): adjust `object-cover` for safari

### DIFF
--- a/app/routes/shows.$showId.tsx
+++ b/app/routes/shows.$showId.tsx
@@ -63,7 +63,7 @@ function About({ className }: { className: string }) {
           Download the <a href={show.video.url}>MP4</a> video.
         </video>
         <div className='flex gap-2'>
-          <div className='flex-none w-40 bg-gray-100 dark:bg-gray-800'>
+          <div className='flex-none w-40 bg-gray-100 dark:bg-gray-800 h-0 min-h-full'>
             <img
               className='object-cover h-full'
               src={show.looks[0].image.url}


### PR DESCRIPTION
Previously, the height of the first look image preview would take the height of the viewport. This resulted in undesired styling.

Fixes: d0367d2e5d4c ("feat(routes/shows): set look image aspect ratio")