### PR TITLE
feat(prisma): add critic review fields

### DIFF
--- a/prisma/migrations/20230721194936_add_review_title_subtitle_summary_and_score/migration.sql
+++ b/prisma/migrations/20230721194936_add_review_title_subtitle_summary_and_score/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "score" DECIMAL(65,30),
+ADD COLUMN     "subtitle" TEXT,
+ADD COLUMN     "summary" TEXT,
+ADD COLUMN     "title" TEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -648,6 +648,18 @@ model Look {
 model Review {
   id Int @id @default(autoincrement())
 
+  // The review title (usually included as the header on their webpage).
+  title String @default("")
+
+  // The review subtitle (typically included below the title on their webpage).
+  subtitle String?
+
+  // The review sentiment score from 0-1 (assigned via OpenAI).
+  score Decimal?
+
+  // The review summary (generated via OpenAI).
+  summary String?
+
   // The review content (typically an HTML string).
   content String
 


### PR DESCRIPTION
This patch adds the title, subtitle, summary, and score fields to the `Review` object. Similar to how Rotten Tomatoes assigns a sentiment (i.e. rotten/fresh) to each critic review, we should do the same. We should also save the title and subtitle from the review in our database. And we should include a short summary of the review that is shown to users until they expand the review to "read more" (similar to Rotten Tomatoes).

Closes: NC-629