### PR TITLE
fix(routes/show): use explicit `emerald` color name

### DIFF
--- a/app/routes/shows.$showId.tsx
+++ b/app/routes/shows.$showId.tsx
@@ -239,7 +239,7 @@ function Score({ value, label, count }: ScoreProps) {
 function Section({ header, children }: PropsWithChildren<{ header: string }>) {
   return (
     <section className='grid gap-2'>
-      <h1 className='border-l-2 border-primary pl-1.5 font-medium text-base uppercase'>
+      <h1 className='border-l-2 border-emerald-700 pl-1.5 font-medium text-base uppercase'>
         {header}
       </h1>
       {children}


### PR DESCRIPTION
This patch updates the show subheader border color to use Tailwind's `emerald-700`. I removed the `primary` color variable and will not be re-introducing it. Tailwind recommends using the literal color names instead of abstract variable names as it leads to less obscure abstraction.

See: https://tailwindcss.com/docs/customizing-colors#naming-your-colors
Fixes: b72c6e9e38ae ("refactor(atoms): remove unused boilerplate components")