### PR TITLE
ci(workflows/migrate): deploy db schema on push

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,31 @@
+name: Migrate 
+on:
+  push:
+    branches: 
+      - main
+
+jobs:
+  deploy:
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+      
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: Download deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply all pending migrations to the database
+        run: pnpm prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
This patch creates a new GitHub Actions workflow called "Migrate" that will automatically deploy our Prisma migrations to our production database on a push to `main`.

See: https://www.prisma.io/docs/guides/deployment/deploy-database-changes-with-prisma-migrate