### PR TITLE
fix(routes/show): style "where to buy" alt text

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -13,12 +13,6 @@
     -moz-text-size-adjust: none;
   }
 
-  /* hide image alt text; see https://stackoverflow.com/a/37192970 */
-  img[alt]:after {
-    @apply absolute inset-0 flex h-full w-full items-center justify-center bg-inherit text-center text-xs;
-    content: attr(alt);
-  }
-
   /* hide outline on focus */
   :focus {
     outline: none;

--- a/app/routes/_layout.join.tsx
+++ b/app/routes/_layout.join.tsx
@@ -59,6 +59,8 @@ export const handle: Handle = {
   breadcrumb: () => <Link to='/join'>sign up</Link>,
 }
 
+export const config = { runtime: 'nodejs' }
+
 export async function loader({ request }: LoaderArgs) {
   const userId = await getUserId(request)
   if (userId) return redirect('/')

--- a/app/routes/_layout.login.tsx
+++ b/app/routes/_layout.login.tsx
@@ -36,6 +36,8 @@ export const handle: Handle = {
   breadcrumb: () => <Link to='/login'>login</Link>,
 }
 
+export const config = { runtime: 'nodejs' }
+
 export async function loader({ request }: LoaderArgs) {
   const userId = await getUserId(request)
   if (userId) return redirect('/')

--- a/app/routes/shows.$showId.tsx
+++ b/app/routes/shows.$showId.tsx
@@ -196,22 +196,38 @@ function WhereToBuy() {
         <ul className='mt-2 flex gap-2'>
           {links.map((link) => (
             <li key={link.id}>
-              <a
-                href={link.url}
-                target='_blank'
-                rel='noopener noreferrer'
-                className={cn(buttonVariants({ variant: 'outline' }), 'h-auto')}
-              >
-                <img
-                  src={(link.brand ?? link.retailer)?.avatar ?? ''}
-                  alt={(link.brand ?? link.retailer ?? show).name}
-                />
-              </a>
+              <BuyLink
+                avatar={(link.brand ?? link.retailer)?.avatar}
+                alt={(link.brand ?? link.retailer ?? show)?.name}
+                url={link.url}
+              />
             </li>
           ))}
         </ul>
       )}
     </Section>
+  )
+}
+
+function BuyLink({
+  avatar,
+  alt,
+  url,
+}: {
+  avatar?: string | null
+  alt: string
+  url: string
+}) {
+  return (
+    <a
+      href={url}
+      target='_blank'
+      rel='noopener noreferrer'
+      className={cn(buttonVariants({ variant: 'outline' }), 'h-auto')}
+    >
+      {avatar != null && <img src={avatar} alt={alt} />}
+      {avatar == null && alt}
+    </a>
   )
 }
 


### PR DESCRIPTION
This patch fixes an issue where the "where to buy" button images were preventing users from scrolling the show page when the image failed to load and the `alt` text was shown. Now, if the image fails to load or if there isn't a valid `avatar` to load, the button simply looks like a text outlined button.