### PR TITLE
fix: users can only submit one review per show

### DIFF
--- a/app/routes/shows.$showId/consumer-reviews.tsx
+++ b/app/routes/shows.$showId/consumer-reviews.tsx
@@ -46,7 +46,7 @@ export function ConsumerReviews() {
                     <TimeAgo
                       locale='en_short'
                       className='text-gray-400 dark:text-gray-500 text-3xs'
-                      datetime={review.createdAt}
+                      datetime={review.updatedAt}
                     />
                   </figcaption>
                   <blockquote className='text-sm'>

--- a/prisma/migrations/20230723233612_users_can_only_submit_one_review_per_show/migration.sql
+++ b/prisma/migrations/20230723233612_users_can_only_submit_one_review_per_show/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[authorId,showId]` on the table `Review` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Review_authorId_showId_key" ON "Review"("authorId", "showId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -787,6 +787,12 @@ model Review {
 
   // The review article URL (if it was posted online e.g. on Vogue).
   url String? @unique
+
+  // Each user can only submit one review per show. This may be different for
+  // critic reviews, but, for now, I've yet to encounter the same journalist
+  // publishing two different reviews for the same show. If that does happen, I
+  // can always just replace their review with whichever is the most recent.
+  @@unique([authorId, showId])
 }
 
 // A publication is a resource that publishes fashion reviews (e.g. Vogue).


### PR DESCRIPTION
This patch adds a unique constraint on the `showId` and `authorId` fields on the `Review` table in Postgres. This patch then updates the "rate and review" section to show the user's existing review if it exists (along with a submit button that reads "Edit review").

Users can only submit a single review per show.

Closes: NC-643