### PR TITLE
fix(shows): sort desc by season and then name

### DIFF
--- a/app/routes/shows._index.tsx
+++ b/app/routes/shows._index.tsx
@@ -23,7 +23,11 @@ export async function loader() {
       collections: true,
       looks: { include: { image: true }, orderBy: { number: 'asc' }, take: 1 },
     },
-    orderBy: { name: 'asc' },
+    orderBy: [
+      { season: { year: 'desc' } },
+      { season: { name: 'desc' } },
+      { name: 'asc' },
+    ],
   })
   log.debug('got %d shows', shows.length)
   return shows


### PR DESCRIPTION
This patch updates the shows page to sort descending by season first and then sort each season by name ascending (i.e. alphabetically).

Note that this does not _entirely_ work as the season name lexicographical order does not necessarily correspond with the season's chronological position.

The ultimate fix for this issue is probably to simply split up the shows page by season. Or simply include season name links to filter by.