### PR TITLE
fix(routes/show): hide empty "about" sections

### DIFF
--- a/app/routes/shows.$showId/consumer-reviews.tsx
+++ b/app/routes/shows.$showId/consumer-reviews.tsx
@@ -18,7 +18,7 @@ export function ConsumerReviews() {
     <Section header={`Consumer reviews for ${show.name}`} id='consumer-reviews'>
       {reviews.length === 0 && (
         <Empty className='mt-2'>
-          No consumer reviews to show yet. Try submitting one above.
+          There are no consumer reviews yet. Try submitting one above.
         </Empty>
       )}
       {reviews.length > 0 && (

--- a/app/routes/shows.$showId/designers.tsx
+++ b/app/routes/shows.$showId/designers.tsx
@@ -15,23 +15,17 @@ import { Section } from './section'
 export function Designers() {
   const show = useLoaderData<typeof loader>()
   const designers = show.collections.flatMap((c) => c.designers)
+  if (designers.length === 0) return null
   return (
     <Section
       header={designers.length === 1 ? 'Designer' : 'Designers'}
       id='designers'
     >
-      {designers.length === 0 && (
-        <Empty className='mt-2'>
-          No designers have claimed this show yet. Please check back later.
-        </Empty>
-      )}
-      {designers.length > 0 && (
-        <ul className='mt-2 grid gap-2'>
-          {designers.map((designer) => (
-            <DesignerItem key={designer.id} designer={designer} />
-          ))}
-        </ul>
-      )}
+      <ul className='mt-2 grid gap-2'>
+        {designers.map((designer) => (
+          <DesignerItem key={designer.id} designer={designer} />
+        ))}
+      </ul>
     </Section>
   )
 }

--- a/app/routes/shows.$showId/what-to-know.tsx
+++ b/app/routes/shows.$showId/what-to-know.tsx
@@ -7,6 +7,8 @@ import { Section } from './section'
 
 export function WhatToKnow() {
   const show = useLoaderData<typeof loader>()
+  if (show.criticReviewSummary == null && show.consumerReviewSummary == null)
+    return null
   return (
     <Section header='What to know' id='what-to-know'>
       <Subheader>Critics Consensus</Subheader>

--- a/app/routes/shows.$showId/where-to-buy.tsx
+++ b/app/routes/shows.$showId/where-to-buy.tsx
@@ -13,6 +13,7 @@ export function WhereToBuy() {
   const show = useLoaderData<typeof loader>()
   const links = show.collections.flatMap((collection) => collection.links)
   const brands = show.brands.filter((brand) => brand.url)
+  if (links.length === 0) return null
   return (
     <Section header='Where to buy' id='where-to-buy'>
       {links.length === 0 && (


### PR DESCRIPTION
This patch hides the empty sections in the left side of the show page. Rotten Tomatoes, when there is no critic or consumer summary, will simply hide that section on the movie page. This change implements similar behavior for almost every section of the "about" left side of the show page.

Note that I did not delete the `<Empty>` state as I may want to re-introduce some of them at some point (e.g. the "where to buy" empty state can sometimes actually be helpful, pointing users to the brand's website where they may be able to find the collection's products).