### PR TITLE
feat(show/scores-header): keep show video on loop

### DIFF
--- a/app/routes/shows.$showId/scores-header.tsx
+++ b/app/routes/shows.$showId/scores-header.tsx
@@ -77,6 +77,7 @@ export function ScoresHeader() {
           autoPlay
           playsInline
           muted
+          loop
         >
           <source src={show.video.url} type={show.video.mimeType} />
           Download the <a href={show.video.url}>MP4</a> video.


### PR DESCRIPTION
This is especially necessary when the show video isn't a recording of a runway show but rather some promotional clips.

Ref: https://nicholas.engineering/shows/351

Tested:

Verified that, in the [preview deployment](https://site-git-nicholas-loop-nicholaschiang.vercel.app/shows/1013), videos looped as expected without user interaction.