### PR TITLE
fix: replace `@radix-ui/react-icons` with `lucide-react`

### DIFF
--- a/app/components/filters.tsx
+++ b/app/components/filters.tsx
@@ -1,10 +1,10 @@
 import type { Level, Prisma } from '@prisma/client'
-import { CaretDownIcon, Cross2Icon, PlusIcon } from '@radix-ui/react-icons'
 import * as Popover from '@radix-ui/react-popover'
 import { useFetcher } from '@remix-run/react'
 import cn from 'classnames'
 import { useCommandState } from 'cmdk'
 import { dequal } from 'dequal/lite'
+import { ChevronDown, X, Plus } from 'lucide-react'
 import { nanoid } from 'nanoid/non-secure'
 import type {
   Dispatch,
@@ -175,7 +175,7 @@ function GenericItem({ name, condition, value, onClick }: GenericItemProps) {
         className='text-gray-400 hover:text-inherit'
         onClick={onClick}
       >
-        <Cross2Icon />
+        <X className='w-3 h-3' />
       </ItemButton>
     </li>
   )
@@ -284,7 +284,7 @@ function AddFilterButton({ model, hiddenFields }: AddFilterButtonProps) {
       <Tooltip tip='Filter' hotkey='f' onHotkey={() => setOpen(true)}>
         <Popover.Trigger asChild>
           <button type='button' className='icon-button square mb-1.5 flex'>
-            <PlusIcon className='h-3.5 w-3.5' />
+            <Plus className='h-3.5 w-3.5' />
           </button>
         </Popover.Trigger>
       </Tooltip>
@@ -549,7 +549,7 @@ function SizeItems({ nested }: Pick<Props, 'nested'>) {
           <Menu.ItemLabel group={nested ? 'sizes' : undefined}>
             <span className='flex items-center truncate text-gray-500'>
               {size.sex}
-              <CaretDownIcon className='mx-2 h-3 w-3 -rotate-90' />
+              <ChevronDown className='mx-2 h-3 w-3 -rotate-90' />
             </span>
             {size.name}
           </Menu.ItemLabel>

--- a/app/components/menu.tsx
+++ b/app/components/menu.tsx
@@ -1,7 +1,7 @@
 import * as Checkbox from '@radix-ui/react-checkbox'
-import { CaretDownIcon, CheckIcon } from '@radix-ui/react-icons'
 import cn from 'classnames'
 import { Command, useCommandState } from 'cmdk'
+import { ChevronDown, Check } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 import { Hotkey } from 'components/hotkey'
@@ -105,7 +105,7 @@ export function Item({
                 checked ? 'opacity-100' : 'opacity-0',
               )}
             >
-              <CheckIcon />
+              <Check className='w-3 h-3' />
             </Checkbox.Indicator>
           </Checkbox.Root>
         )}
@@ -123,7 +123,7 @@ export function ItemLabel({ group, children }: ItemLabelProps) {
       {group && <span className='truncate'>{group}</span>}
       {group && (
         <span className='mr-8 flex flex-1 items-center truncate text-gray-500'>
-          <CaretDownIcon className='mx-2 h-3 w-3 -rotate-90 group-aria-selected:text-gray-900 dark:group-aria-selected:text-gray-100' />
+          <ChevronDown className='mx-2 h-3 w-3 -rotate-90 group-aria-selected:text-gray-900 dark:group-aria-selected:text-gray-100' />
           {children}
         </span>
       )}

--- a/app/components/theme-switcher.tsx
+++ b/app/components/theme-switcher.tsx
@@ -1,5 +1,5 @@
-import { MoonIcon, SunIcon } from '@radix-ui/react-icons'
 import { useFetcher } from '@remix-run/react'
+import { Moon, Sun } from 'lucide-react'
 import { useEffect } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -28,8 +28,8 @@ export function ThemeSwitcher({ className }: { className?: string }) {
       <Tooltip tip='Toggle theme' hotkey='t'>
         <Button type='submit' size='icon' variant='ghost' className={className}>
           <Themed
-            dark={<MoonIcon className='h-3 w-3' />}
-            light={<SunIcon className='h-3 w-3' />}
+            dark={<Moon className='h-3 w-3' />}
+            light={<Sun className='h-3 w-3' />}
           />
         </Button>
       </Tooltip>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,12 +1,11 @@
-import {
-  CameraIcon,
-  ArrowTopRightIcon,
-  CardStackIcon,
-  PersonIcon,
-} from '@radix-ui/react-icons'
-import type { IconProps } from '@radix-ui/react-icons/dist/types'
 import { Link } from '@remix-run/react'
-import type { FunctionComponent } from 'react'
+import {
+  Projector,
+  ExternalLink,
+  Shirt,
+  CalendarClock,
+  type LucideIcon,
+} from 'lucide-react'
 
 export default function IndexPage() {
   return (
@@ -17,14 +16,14 @@ export default function IndexPage() {
           title='/shows'
           subtitle='rotten tomatoes for fashion'
           url='/shows'
-          icon={CameraIcon}
+          icon={Projector}
         />
         <Milestone
           start={new Date(2023, 3, 18)}
           title='/life'
           subtitle='a graphical depiction'
           url='/life/life.pdf'
-          icon={PersonIcon}
+          icon={CalendarClock}
           openInNew
         />
         <Milestone
@@ -32,7 +31,7 @@ export default function IndexPage() {
           title='/products'
           subtitle='a fashion archive'
           url='/products'
-          icon={CardStackIcon}
+          icon={Shirt}
         />
         <Milestone
           start={new Date(2023, 0, 1)}
@@ -96,7 +95,7 @@ interface MilestoneProps {
   title: string
   subtitle: string
   url?: string
-  icon?: FunctionComponent<IconProps>
+  icon?: LucideIcon
   openInNew?: boolean
 }
 
@@ -109,7 +108,7 @@ function Milestone({
   icon,
   openInNew,
 }: MilestoneProps) {
-  const Icon = icon ?? ArrowTopRightIcon
+  const Icon = icon ?? ExternalLink
   return (
     <article className='before:content-[" "] relative m-12 text-lg leading-none before:absolute before:-left-6.5 before:top-1/2 before:h-1 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-gray-300 after:absolute after:-left-[calc(1.5rem_+_0.5px)] after:top-1/2 after:h-[calc(100%_+_3rem)] after:border-l after:border-gray-300 last:after:hidden dark:before:bg-gray-100 dark:after:border-gray-100'>
       <p className='text-xs lowercase text-gray-900/50 dark:text-gray-100/50'>

--- a/app/routes/_layout.products.$productId.tsx
+++ b/app/routes/_layout.products.$productId.tsx
@@ -1,9 +1,3 @@
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  Cross2Icon,
-  InfoCircledIcon,
-} from '@radix-ui/react-icons'
 import * as Popover from '@radix-ui/react-popover'
 import { Link, useLoaderData, useLocation, useNavigate } from '@remix-run/react'
 import {
@@ -11,6 +5,7 @@ import {
   type SerializeFrom,
   type V2_MetaFunction,
 } from '@vercel/remix'
+import { ChevronDown, ChevronUp, X, Info } from 'lucide-react'
 import { type PropsWithChildren, type ReactNode } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import invariant from 'tiny-invariant'
@@ -127,7 +122,7 @@ export default function ProductPage() {
       <div className='flex items-center gap-2.5 border-b border-gray-200/50 bg-gray-50 p-2 px-6 dark:border-gray-700/50 dark:bg-gray-900'>
         <Tooltip tip='close' hotkey='esc'>
           <Dialog.Close className='icon-button square'>
-            <Cross2Icon />
+            <X className='w-3 h-3' />
           </Dialog.Close>
         </Tooltip>
         <div className='flex items-center gap-1'>
@@ -137,7 +132,7 @@ export default function ProductPage() {
             to={`../${productIds[productIndex - 1]}${location.search}`}
             disabled={productIndex <= 0}
           >
-            <ChevronUpIcon />
+            <ChevronUp className='w-3 h-3' />
           </LinkWithHotkey>
           <LinkWithHotkey
             tip='move down'
@@ -145,7 +140,7 @@ export default function ProductPage() {
             to={`../${productIds[productIndex + 1]}${location.search}`}
             disabled={productIndex === productIds.length - 1}
           >
-            <ChevronDownIcon />
+            <ChevronDown className='w-3 h-3' />
           </LinkWithHotkey>
         </div>
         <span className='mt-0.5 text-sm text-gray-600 dark:text-gray-400'>
@@ -352,7 +347,7 @@ Section.Info = function SectionInfo({ children }: PropsWithChildren) {
   return (
     <Popover.Root>
       <Popover.Trigger className='mb-0.5 text-gray-400 aria-expanded:text-gray-600 dark:text-gray-600 aria-expanded:dark:text-gray-400'>
-        <InfoCircledIcon />
+        <Info className='w-3 h-3' />
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content

--- a/app/routes/_layout.products.tsx
+++ b/app/routes/_layout.products.tsx
@@ -1,5 +1,4 @@
 import type { Prisma } from '@prisma/client'
-import { ZoomInIcon, ZoomOutIcon } from '@radix-ui/react-icons'
 import {
   Link,
   Outlet,
@@ -9,6 +8,7 @@ import {
   useSearchParams,
 } from '@remix-run/react'
 import { type LoaderArgs, type V2_MetaFunction } from '@vercel/remix'
+import { ZoomIn, ZoomOut } from 'lucide-react'
 import {
   type Dispatch,
   type SetStateAction,
@@ -239,7 +239,7 @@ export default function ProductsPage() {
                 disabled={resultsPerRow === minResultsPerRow}
                 onClick={zoomIn}
               >
-                <ZoomInIcon className='h-3.5 w-3.5' />
+                <ZoomIn className='h-3.5 w-3.5' />
               </button>
             </Tooltip>
             <Tooltip tip='Zoom Out' hotkey='-' onHotkey={zoomOut}>
@@ -250,7 +250,7 @@ export default function ProductsPage() {
                 disabled={resultsPerRow === maxResultsPerRow}
                 onClick={zoomOut}
               >
-                <ZoomOutIcon className='h-3.5 w-3.5' />
+                <ZoomOut className='h-3.5 w-3.5' />
               </button>
             </Tooltip>
           </div>

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-form": "^0.0.3",
-    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-portal": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,6 @@ dependencies:
   '@radix-ui/react-form':
     specifier: ^0.0.3
     version: 0.0.3(@types/react-dom@18.2.7)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
-  '@radix-ui/react-icons':
-    specifier: ^1.3.0
-    version: 1.3.0(react@18.2.0)
   '@radix-ui/react-label':
     specifier: ^2.0.2
     version: 2.0.2(@types/react-dom@18.2.7)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
@@ -3450,14 +3447,6 @@ packages:
       '@types/react-dom': 18.2.7
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /@radix-ui/react-icons@1.3.0(react@18.2.0):
-    resolution: {integrity: sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==}
-    peerDependencies:
-      react: ^16.x || ^17.x || ^18.x
-    dependencies:
-      react: 18.2.0
     dev: false
 
   /@radix-ui/react-id@1.0.0(react@18.2.0):

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,4 +44,13 @@ To import that JSON file into Postgres, simply move it to `public/data/vogue/sho
 ```
 $ tsc -p scripts/node
 $ node scripts/node/out/vogue.js | pino-pretty
-```  
+```
+
+### Aritzia
+
+To import the already scraped Aritzia product data (see `public/data/aritzia`), simply run the save script:
+
+```
+$ tsc -p scripts/node
+$ node scripts/node/out/aritzia.js | pino-pretty
+``` 


### PR DESCRIPTION
This patch replaces icons everywhere!

I am using `lucide-react` instead of the Radix Icons as Lucide comes with more icons out-of-box and is the default used by `shadcn-ui`.