### PR TITLE
feat(login): authenticate with email or username

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -62,15 +62,14 @@ export async function updateUser(
 }
 
 export async function verifyLogin(
-  email: User['email'],
+  emailOrUsername: User['email'] | User['username'],
   password: Password['hash'],
 ) {
   const userWithPassword = await prisma.user.findFirst({
-    where: { email },
-    include: {
-      password: true,
-    },
+    where: { OR: [{ email: emailOrUsername }, { username: emailOrUsername }] },
+    include: { password: true },
   })
+  console.log('user', userWithPassword)
   if (!userWithPassword || !userWithPassword.password) return null
   const isValid = await bcrypt.compare(password, userWithPassword.password.hash)
   if (!isValid) return null


### PR DESCRIPTION
Users can now, similar to Instagram's login page, authenticate with either their email or their username. Eventually, I'll add phone numbers too and then Instagram and I will be exactly alike.