### PR TITLE
fix(utils/schema): allow single word names

### DIFF
--- a/app/utils/schema.ts
+++ b/app/utils/schema.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod'
 
-export const name = z
-  .string()
-  .trim()
-  .min(1, 'Name is required')
-  .includes(' ', { message: 'Name must include both first and last' })
+export const name = z.string().trim().min(1, 'Name is required')
 
 export const username = z
   .string()


### PR DESCRIPTION
Previously, I required users to provide both their first and last name. This change removes that requirement. New users can claim their first name before it gets taken (e.g. having your name just be "Nicholas" has some kind of clout and anonymity associated with it).