### PR TITLE
perf(routes): lazy load show and look images

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -50,50 +50,6 @@ export const handle: Handle = {
 
 export const config = { runtime: 'edge' }
 
-function Header() {
-  const matches = useMatches()
-  const user = useOptionalUser()
-  return (
-    <header className='sticky top-0 bg-white/80 dark:bg-gray-950/80 backdrop-blur-xl border-b border-gray-200 dark:border-gray-700 px-6 flex items-center justify-between h-10 z-10'>
-      <ol className='flex items-center gap-2'>
-        {matches
-          .filter((match) => match.handle && match.handle.breadcrumb)
-          .map((match, index) => (
-            <Fragment key={match.id}>
-              {index !== 0 && (
-                <span className='text-gray-300 dark:text-gray-600'>/</span>
-              )}
-              <li>{(match.handle as Handle).breadcrumb(match)}</li>
-            </Fragment>
-          ))}
-      </ol>
-      <div className='flex items-center'>
-        {!matches.some((match) => match.id.includes('login')) && (
-          <Link
-            className={buttonVariants({ size: 'icon', variant: 'ghost' })}
-            to={user ? '/logout' : '/login'}
-          >
-            {user ? (
-              <LogOut className='w-3 h-3' />
-            ) : (
-              <LogIn className='w-3 h-3' />
-            )}
-          </Link>
-        )}
-        {user && (
-          <Link
-            className={buttonVariants({ size: 'icon', variant: 'ghost' })}
-            to='/profile'
-          >
-            <User className='w-3 h-3' />
-          </Link>
-        )}
-        <ThemeSwitcher />
-      </div>
-    </header>
-  )
-}
-
 export const links: LinksFunction = () => [
   {
     rel: 'preload',
@@ -208,6 +164,51 @@ export async function loader({ request }: LoaderArgs) {
 
 export type LoaderData = SerializeFrom<typeof loader>
 
+export function ErrorBoundary() {
+  const error = useRouteError()
+  if (isRouteErrorResponse(error))
+    return (
+      <ErrorDisplay>
+        <code>
+          <a
+            href={`https://httpstatuses.io/${error.status}`}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='underline'
+          >
+            {error.status} {error.statusText}
+          </a>
+        </code>
+        <br />
+        <code dangerouslySetInnerHTML={{ __html: String(error.data) }} />
+      </ErrorDisplay>
+    )
+  if (error instanceof Error)
+    return (
+      <ErrorDisplay>
+        <code>{error.message}</code>
+        <br />
+        <code dangerouslySetInnerHTML={{ __html: error.stack ?? '' }} />
+      </ErrorDisplay>
+    )
+  return (
+    <ErrorDisplay>
+      <code>An unexpected runtime error ocurred</code>
+    </ErrorDisplay>
+  )
+}
+
+export default function AppWithProviders() {
+  const data = useLoaderData<typeof loader>()
+  return (
+    <ThemeProvider specifiedTheme={data.theme}>
+      <App data={data}>
+        <Outlet />
+      </App>
+    </ThemeProvider>
+  )
+}
+
 function App({ data, children }: { data?: LoaderData; children: ReactNode }) {
   const [theme] = useTheme()
   const navigation = useNavigation()
@@ -251,6 +252,50 @@ function App({ data, children }: { data?: LoaderData; children: ReactNode }) {
   )
 }
 
+function Header() {
+  const matches = useMatches()
+  const user = useOptionalUser()
+  return (
+    <header className='sticky top-0 bg-white/80 dark:bg-gray-950/80 backdrop-blur-xl border-b border-gray-200 dark:border-gray-700 px-6 flex items-center justify-between h-10 z-10'>
+      <ol className='flex items-center gap-2'>
+        {matches
+          .filter((match) => match.handle && match.handle.breadcrumb)
+          .map((match, index) => (
+            <Fragment key={match.id}>
+              {index !== 0 && (
+                <span className='text-gray-300 dark:text-gray-600'>/</span>
+              )}
+              <li>{(match.handle as Handle).breadcrumb(match)}</li>
+            </Fragment>
+          ))}
+      </ol>
+      <div className='flex items-center'>
+        {!matches.some((match) => match.id.includes('login')) && (
+          <Link
+            className={buttonVariants({ size: 'icon', variant: 'ghost' })}
+            to={user ? '/logout' : '/login'}
+          >
+            {user ? (
+              <LogOut className='w-3 h-3' />
+            ) : (
+              <LogIn className='w-3 h-3' />
+            )}
+          </Link>
+        )}
+        {user && (
+          <Link
+            className={buttonVariants({ size: 'icon', variant: 'ghost' })}
+            to='/profile'
+          >
+            <User className='w-3 h-3' />
+          </Link>
+        )}
+        <ThemeSwitcher />
+      </div>
+    </header>
+  )
+}
+
 function ErrorDisplay({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider specifiedTheme={null}>
@@ -278,51 +323,6 @@ function ErrorDisplay({ children }: { children: ReactNode }) {
             </div>
           </article>
         </div>
-      </App>
-    </ThemeProvider>
-  )
-}
-
-export function ErrorBoundary() {
-  const error = useRouteError()
-  if (isRouteErrorResponse(error))
-    return (
-      <ErrorDisplay>
-        <code>
-          <a
-            href={`https://httpstatuses.io/${error.status}`}
-            target='_blank'
-            rel='noopener noreferrer'
-            className='underline'
-          >
-            {error.status} {error.statusText}
-          </a>
-        </code>
-        <br />
-        <code dangerouslySetInnerHTML={{ __html: String(error.data) }} />
-      </ErrorDisplay>
-    )
-  if (error instanceof Error)
-    return (
-      <ErrorDisplay>
-        <code>{error.message}</code>
-        <br />
-        <code dangerouslySetInnerHTML={{ __html: error.stack ?? '' }} />
-      </ErrorDisplay>
-    )
-  return (
-    <ErrorDisplay>
-      <code>An unexpected runtime error ocurred</code>
-    </ErrorDisplay>
-  )
-}
-
-export default function AppWithProviders() {
-  const data = useLoaderData<typeof loader>()
-  return (
-    <ThemeProvider specifiedTheme={data.theme}>
-      <App data={data}>
-        <Outlet />
       </App>
     </ThemeProvider>
   )

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -45,7 +45,11 @@ import { useOptionalUser } from 'utils'
 export type Handle = { breadcrumb: (match: RouteMatch) => ReactNode }
 
 export const handle: Handle = {
-  breadcrumb: () => <Link to='/'>nicholas.engineering</Link>,
+  breadcrumb: () => (
+    <Link prefetch='intent' to='/'>
+      nicholas.engineering
+    </Link>
+  ),
 }
 
 export const config = { runtime: 'edge' }

--- a/app/routes/_layout.join.tsx
+++ b/app/routes/_layout.join.tsx
@@ -126,6 +126,7 @@ export default function Join() {
           <p className='text-sm text-gray-500 dark:text-gray-400'>
             Already have an account?{' '}
             <Link
+              prefetch='intent'
               className='underline'
               to={redirectTo ? `/login?redirectTo=${redirectTo}` : '/login'}
             >

--- a/app/routes/_layout.login.tsx
+++ b/app/routes/_layout.login.tsx
@@ -104,6 +104,7 @@ export default function LoginPage() {
           <p className='text-sm text-gray-500 dark:text-gray-400'>
             Don’t have an account?{' '}
             <Link
+              prefetch='intent'
               className='underline'
               to={redirectTo ? `/join?redirectTo=${redirectTo}` : '/join'}
             >

--- a/app/routes/_layout.products.$productId.tsx
+++ b/app/routes/_layout.products.$productId.tsx
@@ -26,7 +26,10 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => [
 
 export const handle: Handle = {
   breadcrumb: (match) => (
-    <Link to={`/products/${match.params.productId as string}`}>
+    <Link
+      prefetch='intent'
+      to={`/products/${match.params.productId as string}`}
+    >
       {(match.data as SerializeFrom<typeof loader>)?.name ?? '404'}
     </Link>
   ),

--- a/app/routes/_layout.products.tsx
+++ b/app/routes/_layout.products.tsx
@@ -316,7 +316,7 @@ function ProductItem({
               src={images[1]}
               responsive={[200, 300, 400, 500, 600, 700, 800, 900, 1000].map(
                 (width) => ({
-                  size: { width, height: width * widthToHeightImageRatio },
+                  size: { width },
                   maxWidth: width * resultsPerRow,
                 }),
               )}

--- a/app/routes/_layout.products.tsx
+++ b/app/routes/_layout.products.tsx
@@ -41,7 +41,11 @@ export const meta: V2_MetaFunction = () => [
 ]
 
 export const handle: Handle = {
-  breadcrumb: () => <Link to='/products'>products</Link>,
+  breadcrumb: () => (
+    <Link prefetch='intent' to='/products'>
+      products
+    </Link>
+  ),
 }
 
 enum Join {

--- a/app/routes/shows.$showId/rate-and-review.tsx
+++ b/app/routes/shows.$showId/rate-and-review.tsx
@@ -106,6 +106,7 @@ export function RateAndReview() {
         >
           {user == null && (
             <Link
+              prefetch='intent'
               to={`/login?redirectTo=${location.pathname}%23${id}`}
               className='absolute inset-0 z-10'
             />

--- a/app/routes/shows.$showId/route.tsx
+++ b/app/routes/shows.$showId/route.tsx
@@ -50,7 +50,7 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
 
 export const handle: Handle = {
   breadcrumb: (match) => (
-    <Link to={`/shows/${match.params.showId as string}`}>
+    <Link prefetch='intent' to={`/shows/${match.params.showId as string}`}>
       {(match.data as SerializeFrom<typeof loader>)?.name ?? '404'}
     </Link>
   ),

--- a/app/routes/shows.$showId/route.tsx
+++ b/app/routes/shows.$showId/route.tsx
@@ -22,6 +22,12 @@ import { WhereToBuy } from './where-to-buy'
 
 export { action } from './rate-and-review'
 
+// Eagerly load images for the first three rows of looks (above the fold).
+const rowsToEagerLoad = 3
+
+// How many looks are shown in each row of results.
+const looksPerRow = 2
+
 export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
   if (data == null) return [{ title: '404 | Nicholas Chiang' }]
   const keywords = [
@@ -95,12 +101,23 @@ function Looks({ className }: { className: string }) {
   const show = useLoaderData<typeof loader>()
   return (
     <div className={cn('overflow-auto', className)}>
-      <ol className='grid grid-cols-2 gap-x-2 gap-y-6'>
-        {show.looks.map((look) => (
+      <ol
+        className='grid gap-x-2 gap-y-6'
+        style={{
+          gridTemplateColumns: `repeat(${looksPerRow}, minmax(0, 1fr))`,
+        }}
+      >
+        {show.looks.map((look, index) => (
           <li key={look.id}>
             <div className='bg-gray-100 dark:bg-gray-900 aspect-person'>
               <img
                 className='object-cover h-full w-full'
+                loading={
+                  index < looksPerRow * rowsToEagerLoad ? 'eager' : 'lazy'
+                }
+                decoding={
+                  index < looksPerRow * rowsToEagerLoad ? 'sync' : 'async'
+                }
                 src={look.image.url}
                 alt=''
               />

--- a/app/routes/shows.$showId/scores-header.tsx
+++ b/app/routes/shows.$showId/scores-header.tsx
@@ -71,23 +71,34 @@ export function ScoresHeader() {
   return (
     <div className='grid gap-2'>
       {show.video != null && (
-        <video
-          className='aspect-video w-full bg-gray-100 dark:bg-gray-900'
-          controls
-          autoPlay
-          playsInline
-          muted
-          loop
-        >
-          <source src={show.video.url} type={show.video.mimeType} />
-          Download the <a href={show.video.url}>MP4</a> video.
-        </video>
+        <>
+          <video
+            className='aspect-video w-full bg-gray-100 dark:bg-gray-900'
+            preload='auto'
+            controls
+            autoPlay
+            playsInline
+            muted
+            loop
+          >
+            <source src={show.video.url} type={show.video.mimeType} />
+            Download the <a href={show.video.url}>MP4</a> video.
+          </video>
+          <link
+            rel='preload'
+            href={show.video.url}
+            type={show.video.mimeType}
+            as='video'
+          />
+        </>
       )}
       <div className='flex gap-2'>
         <div className='flex-none w-40 bg-gray-100 dark:bg-gray-900 h-0 min-h-full'>
           <img
             className='object-cover h-full w-full'
             src={show.looks[0].image.url}
+            loading='eager'
+            decoding='sync'
             alt=''
           />
         </div>

--- a/app/routes/shows._index.tsx
+++ b/app/routes/shows._index.tsx
@@ -2,6 +2,7 @@ import { Link, useLoaderData } from '@remix-run/react'
 import { type V2_MetaFunction } from '@vercel/remix'
 
 import { Empty } from 'components/empty'
+import { Image } from 'components/image'
 
 import { prisma } from 'db.server'
 import { log } from 'log.server'
@@ -35,21 +36,43 @@ export async function loader() {
   return shows
 }
 
+// Eagerly load images for the first two rows of shows (above the fold).
+const rowsToEagerLoad = 2
+
+// How many shows are shown in each row of results.
+const showsPerRow = 5
+
 export default function ShowsPage() {
   const shows = useLoaderData<typeof loader>()
   return (
     <main className='p-6 mx-auto max-w-screen-xl'>
       <h1 className='text-6xl mb-6'>shows</h1>
       {shows.length > 0 ? (
-        <ul className='grid grid-cols-5 gap-x-2 gap-y-10'>
-          {shows.map((show) => (
+        <ul
+          className='grid gap-x-2 gap-y-10'
+          style={{
+            gridTemplateColumns: `repeat(${showsPerRow}, minmax(0, 1fr))`,
+          }}
+        >
+          {shows.map((show, index) => (
             <li key={show.id}>
               <Link to={`/shows/${show.id}`}>
                 <div className='bg-gray-100 dark:bg-gray-900 aspect-person mb-2'>
-                  <img
+                  <Image
                     className='object-cover h-full w-full'
+                    loading={
+                      index < showsPerRow * rowsToEagerLoad ? 'eager' : 'lazy'
+                    }
+                    decoding={
+                      index < showsPerRow * rowsToEagerLoad ? 'sync' : 'async'
+                    }
                     src={show.looks[0].image.url}
-                    alt=''
+                    responsive={[
+                      100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
+                    ].map((width) => ({
+                      size: { width },
+                      maxWidth: width * showsPerRow,
+                    }))}
                   />
                 </div>
                 <h2 className='text-xl font-serif font-semibold text-center'>

--- a/app/routes/shows._index.tsx
+++ b/app/routes/shows._index.tsx
@@ -56,7 +56,7 @@ export default function ShowsPage() {
         >
           {shows.map((show, index) => (
             <li key={show.id}>
-              <Link to={`/shows/${show.id}`}>
+              <Link prefetch='intent' to={`/shows/${show.id}`}>
                 <div className='bg-gray-100 dark:bg-gray-900 aspect-person mb-2'>
                   <Image
                     className='object-cover h-full w-full'

--- a/app/routes/shows.tsx
+++ b/app/routes/shows.tsx
@@ -3,7 +3,11 @@ import { Link, Outlet } from '@remix-run/react'
 import { type Handle } from 'root'
 
 export const handle: Handle = {
-  breadcrumb: () => <Link to='/shows'>shows</Link>,
+  breadcrumb: () => (
+    <Link prefetch='intent' to='/shows'>
+      shows
+    </Link>
+  ),
 }
 
 export default function ShowsLayout() {

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "images": {
-    "sizes": [200, 300, 400, 500, 600, 700, 800, 900, 1000],
-    "domains": ["aritzia.scene7.com"],
+    "sizes": [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+    "domains": ["assets.vogue.com", "aritzia.scene7.com"],
     "minimumCacheTTL": 60,
     "formats": ["image/webp", "image/avif"]
   },


### PR DESCRIPTION
This patch updates the show and shows list routes to lazy load the look and show images respectively. This patch also adds a responsive `srcset` to the shows list page. This patch also adds a somewhat redundant `preload='auto'` attribute to the show runway video (redundant because we're already telling the browser to preload the video by setting auto play to true).

Closes: NC-675
Closes: NC-676