### PR TITLE
fix(show): do not try to load missing look images

### DIFF
--- a/app/routes/shows.$seasonYear.$seasonName.($sex).$brandSlug/scores-header.tsx
+++ b/app/routes/shows.$seasonYear.$seasonName.($sex).$brandSlug/scores-header.tsx
@@ -35,13 +35,15 @@ export function ScoresHeader() {
       )}
       <div className='flex gap-2'>
         <div className='flex-none w-40 bg-gray-100 dark:bg-gray-900 h-0 min-h-full'>
-          <img
-            className='object-cover h-full w-full'
-            src={show.looks[0]?.images[0]?.url}
-            loading='eager'
-            decoding='sync'
-            alt=''
-          />
+          {show.looks.length > 0 && show.looks[0].images.length > 0 && (
+            <img
+              className='object-cover h-full w-full'
+              src={show.looks[0].images[0].url}
+              loading='eager'
+              decoding='sync'
+              alt=''
+            />
+          )}
         </div>
         <article className='flex-1 bg-gray-100 dark:bg-gray-900 text-center px-6 flex flex-col'>
           <h1 className='font-serif font-bold text-5xl mb-1 mt-8'>

--- a/app/routes/shows._index.tsx
+++ b/app/routes/shows._index.tsx
@@ -218,28 +218,30 @@ export default function ShowsPage() {
                         show == null && 'animate-pulse',
                       )}
                     >
-                      {show != null && show.looks.length > 0 && (
-                        <Image
-                          className='object-cover h-full w-full'
-                          loading={
-                            virtualRow.index < showsPerRow * rowsToEagerLoad
-                              ? 'eager'
-                              : 'lazy'
-                          }
-                          decoding={
-                            virtualRow.index < showsPerRow * rowsToEagerLoad
-                              ? 'sync'
-                              : 'async'
-                          }
-                          src={show.looks[0].images[0]?.url}
-                          responsive={[
-                            100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
-                          ].map((width) => ({
-                            size: { width },
-                            maxWidth: width * showsPerRow,
-                          }))}
-                        />
-                      )}
+                      {show != null &&
+                        show.looks.length > 0 &&
+                        show.looks[0].images.length > 0 && (
+                          <Image
+                            className='object-cover h-full w-full'
+                            loading={
+                              virtualRow.index < showsPerRow * rowsToEagerLoad
+                                ? 'eager'
+                                : 'lazy'
+                            }
+                            decoding={
+                              virtualRow.index < showsPerRow * rowsToEagerLoad
+                                ? 'sync'
+                                : 'async'
+                            }
+                            src={show.looks[0].images[0].url}
+                            responsive={[
+                              100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
+                            ].map((width) => ({
+                              size: { width },
+                              maxWidth: width * showsPerRow,
+                            }))}
+                          />
+                        )}
                     </div>
                     <h2 className='text-xl font-serif font-semibold text-center'>
                       {show?.brand.name}


### PR DESCRIPTION
This patch updates the show page and the shows list to omit the `<img>` tag if the show has no looks that have images. This should almost never happen, but can occur occasionally if a show was imported from a source that did not include any look images.

Ref: https://nicholas.engineering/shows/2022/spring/foo-and-foo