### PR TITLE
refactor(routes): return props from breadcrumb handle

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,4 +1,4 @@
-import { Link, useMatches } from '@remix-run/react'
+import { Link, type LinkProps, useMatches } from '@remix-run/react'
 import { User, LogIn, LogOut, ChevronRight } from 'lucide-react'
 import { type PropsWithChildren, Fragment } from 'react'
 
@@ -37,7 +37,7 @@ export function HeaderWrapper({
 export function HeaderBreadcrumbs() {
   const matches = useMatches()
   return (
-    <ol className='flex items-center gap-2 text-lg tracking-tighter lowercase'>
+    <ol className='flex items-center gap-2'>
       {matches
         .filter((match) => match.handle && match.handle.breadcrumb)
         .map((match, index) => (
@@ -45,10 +45,21 @@ export function HeaderBreadcrumbs() {
             {index !== 0 && (
               <ChevronRight className='text-gray-300 dark:text-gray-600 h-4 w-4 mt-0.5' />
             )}
-            <li>{(match.handle as Handle).breadcrumb(match)}</li>
+            <li>
+              <HeaderLink {...(match.handle as Handle).breadcrumb(match)} />
+            </li>
           </Fragment>
         ))}
     </ol>
+  )
+}
+
+export function HeaderLink({ className, ...etc }: LinkProps) {
+  return (
+    <Link
+      className={cn('text-lg tracking-tighter lowercase', className)}
+      {...etc}
+    />
   )
 }
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,6 +12,7 @@ import {
   useNavigation,
   useNavigationType,
   type RouteMatch,
+  type LinkProps,
 } from '@remix-run/react'
 import { Analytics } from '@vercel/analytics/react'
 import {
@@ -38,14 +39,10 @@ import {
 } from 'theme'
 import { NAME } from 'utils'
 
-export type Handle = { breadcrumb: (match: RouteMatch) => ReactNode }
+export type Handle = { breadcrumb: (match: RouteMatch) => LinkProps }
 
 export const handle: Handle = {
-  breadcrumb: () => (
-    <Link prefetch='intent' to='/'>
-      dolce
-    </Link>
-  ),
+  breadcrumb: () => ({ to: '/', children: 'dolce' }),
 }
 
 export const config = { runtime: 'edge' }

--- a/app/routes/_header.join.tsx
+++ b/app/routes/_header.join.tsx
@@ -53,7 +53,7 @@ const schema = z.object({
 })
 
 export const handle: Handle = {
-  breadcrumb: () => <Link to='/join'>sign up</Link>,
+  breadcrumb: () => ({ to: '/join', children: 'sign up' }),
 }
 
 export const config = { runtime: 'nodejs' }

--- a/app/routes/_header.login.tsx
+++ b/app/routes/_header.login.tsx
@@ -45,7 +45,7 @@ const schema = z.object({
 })
 
 export const handle: Handle = {
-  breadcrumb: () => <Link to='/login'>login</Link>,
+  breadcrumb: () => ({ to: '/login', children: 'login' }),
 }
 
 export const config = { runtime: 'nodejs' }

--- a/app/routes/_header.shows.$seasonYear.$seasonName.($sex).$brandSlug/route.tsx
+++ b/app/routes/_header.shows.$seasonYear.$seasonName.($sex).$brandSlug/route.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from '@remix-run/react'
+import { useLoaderData } from '@remix-run/react'
 import {
   type LoaderArgs,
   type SerializeFrom,
@@ -63,11 +63,7 @@ export const sitemap: SitemapFunction = async () => {
 export const handle: Handle = {
   breadcrumb: (match) => {
     const data = match.data as SerializeFrom<typeof loader> | undefined
-    return (
-      <Link prefetch='intent' to={data ? getShowPath(data) : '.'}>
-        {data?.name ?? '404'}
-      </Link>
-    )
+    return { to: data ? getShowPath(data) : '.', children: data?.name ?? '404' }
   },
 }
 

--- a/app/routes/_header.shows.tsx
+++ b/app/routes/_header.shows.tsx
@@ -1,13 +1,9 @@
-import { Link, Outlet } from '@remix-run/react'
+import { Outlet } from '@remix-run/react'
 
 import { type Handle } from 'root'
 
 export const handle: Handle = {
-  breadcrumb: () => (
-    <Link prefetch='intent' to='/shows'>
-      shows
-    </Link>
-  ),
+  breadcrumb: () => ({ to: '/shows', children: 'shows' }),
 }
 
 export default function ShowsLayout() {

--- a/app/routes/_index/header.tsx
+++ b/app/routes/_index/header.tsx
@@ -1,8 +1,7 @@
-import { Link } from '@remix-run/react'
 import { ChevronRight, Plus } from 'lucide-react'
 import { Fragment } from 'react'
 
-import { HeaderWrapper, HeaderActions } from 'components/header'
+import { HeaderWrapper, HeaderActions, HeaderLink } from 'components/header'
 
 const links = [
   { to: '/shows', label: 'Shows' },
@@ -23,9 +22,9 @@ export function Header() {
               <Plus className='text-gray-300 dark:text-gray-600 h-4 w-4 mt-0.5' />
             )}
             <li className='text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors'>
-              <Link prefetch='intent' to={link.to}>
+              <HeaderLink prefetch='intent' to={link.to}>
                 {link.label}
-              </Link>
+              </HeaderLink>
             </li>
           </Fragment>
         ))}

--- a/app/routes/_layout.products.$productId.tsx
+++ b/app/routes/_layout.products.$productId.tsx
@@ -25,14 +25,10 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => [
 ]
 
 export const handle: Handle = {
-  breadcrumb: (match) => (
-    <Link
-      prefetch='intent'
-      to={`/products/${match.params.productId as string}`}
-    >
-      {(match.data as SerializeFrom<typeof loader>)?.name ?? '404'}
-    </Link>
-  ),
+  breadcrumb: (match) => ({
+    to: `/products/${match.params.productId as string}`,
+    children: (match.data as SerializeFrom<typeof loader>)?.name ?? '404',
+  }),
 }
 
 export async function loader({ params }: LoaderArgs) {

--- a/app/routes/_layout.products.tsx
+++ b/app/routes/_layout.products.tsx
@@ -40,11 +40,7 @@ import { NAME } from 'utils'
 export const meta: V2_MetaFunction = () => [{ title: `Products | ${NAME}` }]
 
 export const handle: Handle = {
-  breadcrumb: () => (
-    <Link prefetch='intent' to='/products'>
-      products
-    </Link>
-  ),
+  breadcrumb: () => ({ to: '/products', children: 'products' }),
 }
 
 enum Join {

--- a/app/routes/_layout.profile.tsx
+++ b/app/routes/_layout.profile.tsx
@@ -2,7 +2,6 @@ import { useForm } from '@conform-to/react'
 import { parse } from '@conform-to/zod'
 import {
   Form as RemixForm,
-  Link,
   useActionData,
   useNavigation,
 } from '@remix-run/react'
@@ -50,7 +49,7 @@ const schema = z.object({
 })
 
 export const handle: Handle = {
-  breadcrumb: () => <Link to='/profile'>profile</Link>,
+  breadcrumb: () => ({ to: '/profile', children: 'profile' }),
 }
 
 export const config = { runtime: 'nodejs' }


### PR DESCRIPTION
This patch updates the `Handle` type definition to accept a function that returns `LinkProps` instead of the actual `<Link>`. This reduces code duplication and allows me to update the styling of every breadcrumb component in the single `<HeaderLink>` component definition.