### PR TITLE
feat: automatically revalidate on focus or reconnect

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -38,6 +38,10 @@ import {
   useTheme,
 } from 'theme'
 import { NAME } from 'utils'
+import {
+  useRevalidateOnFocus,
+  useRevalidateOnReconnect,
+} from 'utils/revalidate'
 
 export type Handle = { breadcrumb: (match: RouteMatch) => LinkProps }
 
@@ -220,6 +224,10 @@ function App({ data, children }: { data?: LoaderData; children: ReactNode }) {
       return () => clearTimeout(timeoutId)
     }
   }, [navigation.state, type])
+
+  useRevalidateOnFocus()
+  useRevalidateOnReconnect()
+
   return (
     <html lang='en' className={cn('h-full', theme)}>
       <head>

--- a/app/utils/revalidate.ts
+++ b/app/utils/revalidate.ts
@@ -1,0 +1,42 @@
+import { useRevalidator } from '@remix-run/react'
+import { useEffect } from 'react'
+
+/**
+ * Hook to automatically revalidate the page data on tab focus.
+ * @see {@link https://sergiodxa.com/articles/automatic-revalidation-in-remix#revalidate-on-focus}
+ */
+export function useRevalidateOnFocus() {
+  const { revalidate } = useRevalidator()
+
+  useEffect(() => {
+    function onFocus() {
+      revalidate()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [revalidate])
+
+  useEffect(() => {
+    function onVisibilityChange() {
+      revalidate()
+    }
+    window.addEventListener('visibilitychange', onVisibilityChange)
+    return () =>
+      window.removeEventListener('visibilitychange', onVisibilityChange)
+  }, [revalidate])
+}
+
+/**
+ * Hook to automatically revalidate the page data on network reconnection.
+ * @see {@link https://sergiodxa.com/articles/automatic-revalidation-in-remix#revalidate-on-reconnect
+ */
+export function useRevalidateOnReconnect() {
+  const { revalidate } = useRevalidator()
+  useEffect(() => {
+    function onReconnect() {
+      revalidate()
+    }
+    window.addEventListener('online', onReconnect)
+    return () => window.removeEventListener('online', onReconnect)
+  }, [revalidate])
+}


### PR DESCRIPTION
This patch enables automatic revalidation on page focus or network reconnect. This mimics SWR behavior (e.g. Vercel's `useSWR`) and makes for an excellent user experience: if I login to one tab, and then switch to another tab, that next tab will show me logged in automatically.

Ref: https://sergiodxa.com/articles/automatic-revalidation-in-remix