### PR TITLE
feat(root): add full story session recording

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ SESSION_SECRET="super-duper-s3cret"
 # supabase
 SUPABASE_URL=""
 SUPABASE_KEY=""
+
+# analytics
+FULLSTORY_ORG_ID=""
+FULLSTORY_DEV_MODE="true"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@conform-to/react": "^0.7.4",
     "@conform-to/zod": "^0.7.4",
+    "@fullstory/browser": "^1.7.1",
     "@prisma/client": "^4.16.2",
     "@radix-ui/react-avatar": "^1.0.3",
     "@radix-ui/react-checkbox": "^1.0.4",
@@ -103,10 +104,10 @@
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@google/semantic-release-replace-plugin": "^1.2.0",
+    "@remix-run/dev": "1.19.2",
     "@remix-run/eslint-config": "1.19.2",
     "@remix-run/node": "1.19.2",
     "@remix-run/serve": "1.19.2",
-    "@remix-run/dev": "1.19.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@tailwindcss/typography": "^0.5.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ dependencies:
   '@conform-to/zod':
     specifier: ^0.7.4
     version: 0.7.4(@conform-to/dom@0.7.4)(zod@3.21.4)
+  '@fullstory/browser':
+    specifier: ^1.7.1
+    version: 1.7.1
   '@prisma/client':
     specifier: ^4.16.2
     version: 4.16.2(prisma@4.16.2)
@@ -2715,6 +2718,16 @@ packages:
       '@floating-ui/dom': 1.3.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@fullstory/browser@1.7.1:
+    resolution: {integrity: sha512-IBPisG+xRyTHHX8XkZJkQRbP2hVYNMZUYW8R3YiB582dl/VZImkFN+LopIAfPqB97FAZgUTofi7flkrHT4Qmtg==}
+    dependencies:
+      '@fullstory/snippet': 1.3.1
+    dev: false
+
+  /@fullstory/snippet@1.3.1:
+    resolution: {integrity: sha512-NgrBWGHH5i8zejlRFSyJNhovkNqHAXsWKrcXIWaABrgESwbkdGETjOU7BD7d1ZeT0X+QXL/2yr/1y4xnWfVkwQ==}
     dev: false
 
   /@gar/promisify@1.1.3:


### PR DESCRIPTION
This patch adds FullStory session recording for seeing how beta users and visitors use the site. I'm going to start pushing it to Instagram models, and I want to see how it is used and where there is friction.

Ref: https://www.npmjs.com/package/@fullstory/browser

Closes: NC-648

Tested:

https://github.com/nicholaschiang/dolce/assets/20798889/517a94dc-79c1-49aa-8ab3-d4320fcf2654