### PR TITLE
fix: remove special characters from brand slugs

### DIFF
--- a/prisma/migrations/20230810205232_remove_special_characters_from_brand_slug/migration.sql
+++ b/prisma/migrations/20230810205232_remove_special_characters_from_brand_slug/migration.sql
@@ -1,0 +1,61 @@
+-- Remove all special characters from brand slugs.
+-- @see {@link https://stackoverflow.com/a/37511463}
+-- @see {@link https://stackoverflow.com/a/2199565}
+-- @see {@link https://stackoverflow.com/a/62782969}
+-- @see {@link https://www.postgresql.org/docs/current/unaccent.html}
+CREATE OR REPLACE TEMP VIEW "BrandWithSlug" AS
+SELECT
+  REGEXP_REPLACE(NORMALIZE("slug", NFKD), '[\x0300-\x036f]', '', 'g') as "normalized_slug",
+  REGEXP_REPLACE(NORMALIZE("slug", NFKD), E'[\\x0300-\\x036f\\x2019\'"]', '', 'g') as "unquoted_normalized_slug",
+  *
+FROM "Brand";
+
+-- See if there are any duplicate brands.
+CREATE OR REPLACE TEMP VIEW "DuplicateBrands" AS
+SELECT "unquoted_normalized_slug", ARRAY_AGG("BrandWithSlug"."id") AS "id", MAX("id") "idmax"
+FROM "BrandWithSlug"
+GROUP BY "unquoted_normalized_slug"
+HAVING COUNT(*) > 1;
+
+-- Combine duplicates. For every show:
+-- (a) move all reviews to the last created show (i.e. the larger "ID");
+-- (b) add all look images to the last created show;
+-- (c) punt on all other relations as they aren't populated yet;
+-- (d) delete the duplicate show;
+-- (e) delete the duplicate brand.
+
+-- Note this only works given the assumption that the most recently created brand
+-- is also associated with the most recently created show, looks, images, etc.
+--
+-- This assumption is generally correct as I import brands, shows, looks, and images
+-- all at the same time. Should this change in the future, this migration will no longer
+-- work (but then again, it won't have to because it will have already been applied).
+
+CREATE OR REPLACE TEMP VIEW "DuplicateShows" AS
+SELECT ARRAY_AGG("Show"."id") "id", MAX("Show"."id") "idmax", "DuplicateBrands"."idmax" "brandId"
+FROM "Show"
+INNER JOIN "DuplicateBrands" ON "Show"."brandId" = ANY("DuplicateBrands"."id")
+GROUP BY "DuplicateBrands"."idmax", "seasonId", "sex", "level"
+HAVING COUNT(*) > 1;
+
+CREATE OR REPLACE TEMP VIEW "DuplicateLooks" AS
+SELECT ARRAY_AGG("Look"."id") "id", MAX("Look"."id") "idmax", "DuplicateShows"."idmax" "showId"
+FROM "Look"
+INNER JOIN "DuplicateShows" ON "Look"."showId" = ANY("DuplicateShows"."id")
+GROUP BY "DuplicateShows"."idmax", "Look"."number"
+HAVING COUNT(*) > 1;
+
+-- (a) move all reviews to the last created show (i.e. the larger "ID");
+UPDATE "Review" SET "showId" = "DuplicateShows"."idmax" FROM "DuplicateShows"
+WHERE "Review"."showId" = ANY("DuplicateShows"."id") AND "Review"."showId" != "DuplicateShows"."idmax";
+
+-- (b) add all look images to the last created show;
+UPDATE "Image" SET "lookId" = "DuplicateLooks"."idmax" FROM "DuplicateLooks"
+WHERE "Image"."lookId" = ANY("DuplicateLooks"."id") AND "Image"."lookId" != "DuplicateLooks"."idmax";
+
+-- Delete duplicates (i.e. the smaller "ID" as we're keeping the larger "ID").
+DELETE FROM "Brand" USING "DuplicateBrands"
+WHERE "Brand"."id" = ANY("DuplicateBrands"."id") AND "Brand"."id" != "DuplicateBrands"."idmax";
+
+-- Update the brand slugs (to remove special characters).
+UPDATE "Brand" SET "slug" = "unquoted_normalized_slug" FROM "BrandWithSlug" WHERE "BrandWithSlug"."id" = "Brand"."id";

--- a/scripts/node/save/utils.ts
+++ b/scripts/node/save/utils.ts
@@ -9,4 +9,6 @@ export function slug(name: string) {
     .toLowerCase()
     .replace(/[.,/#!$%^&*;:{}=\-_`~()\s]+/g, '-')
     .replace(/-$/, '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f\u2019'"]/g, '')
 }


### PR DESCRIPTION
This patch adds a Prisma migration and an update to the Node.js data save scripts to ensure that there are no special characters in the brand slugs. This fixes an issue where unsafe strings were being put into URL paths without proper encoding, resulting in redirect issues and 404s.

This Prisma migration is much more complex than one might expect for a simple string replacement as there were a few duplicate brands that share a normalized slug but had different non-normalized special characters in their original slug. Because of the unique constraint on the brand slug column, I had to remediate this issue by combining those duplicates before updating the slug column.

Ref: https://stackoverflow.com/a/37511463
Ref: https://stackoverflow.com/a/2199565
Ref: https://stackoverflow.com/a/62782969
Ref: https://www.postgresql.org/docs/current/unaccent.html

Closes: NC-686