### PR TITLE
fix(show/looks): do not try to show missing images

### DIFF
--- a/app/routes/_header.shows.$seasonYear.$seasonName.($sex).$brandSlug/looks.tsx
+++ b/app/routes/_header.shows.$seasonYear.$seasonName.($sex).$brandSlug/looks.tsx
@@ -54,13 +54,15 @@ function LookItem({ look }: { look: Look }) {
   return (
     <li>
       <div className='bg-gray-100 dark:bg-gray-900 aspect-person'>
-        <img
-          className='object-cover h-full w-full'
-          loading={index < looksPerRow * rowsToEagerLoad ? 'eager' : 'lazy'}
-          decoding={index < looksPerRow * rowsToEagerLoad ? 'sync' : 'async'}
-          src={look.images[0]?.url}
-          alt=''
-        />
+        {look.images.length > 0 && (
+          <img
+            className='object-cover h-full w-full'
+            loading={index < looksPerRow * rowsToEagerLoad ? 'eager' : 'lazy'}
+            decoding={index < looksPerRow * rowsToEagerLoad ? 'sync' : 'async'}
+            src={look.images[0].url}
+            alt=''
+          />
+        )}
       </div>
       <div className='flex justify-between items-center mt-1'>
         <p className='text-sm'>Look {look.number}</p>


### PR DESCRIPTION
This patch fixes an issue where the show page would try to load images for looks that did not have them. Now, we just show the gray fallback placeholder if a look does not have an image.