### PR TITLE
feat(index): add meta title and capitalization

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,6 +1,6 @@
 import { Location } from '@prisma/client'
 import { Link, useFetcher, useLoaderData } from '@remix-run/react'
-import { type SerializeFrom } from '@vercel/remix'
+import { type V2_MetaFunction, type SerializeFrom } from '@vercel/remix'
 import { scaleLinear } from 'd3-scale'
 import { X } from 'lucide-react'
 import { useCallback, useRef, useMemo } from 'react'
@@ -27,6 +27,7 @@ import {
 } from 'components/ui/popover'
 
 import { cn } from 'utils/cn'
+import { NAME } from 'utils/general'
 import { LOCATION_TO_NAME, LOCATION_TO_COORDINATES } from 'utils/location'
 
 import { prisma } from 'db.server'
@@ -39,6 +40,10 @@ type Count = {
   showsCount: number
   brandsCount: number
 }
+
+export const meta: V2_MetaFunction = () => [
+  { title: `DOLCE: The Worldwide Fashion Database | ${NAME}` },
+]
 
 export async function loader() {
   // TODO I am currently doing these aggregations in-memory as Prisma does not
@@ -72,9 +77,9 @@ export default function HomePage() {
       <Header />
       <section className='p-6 mt-6 mx-auto max-w-screen-xl w-full'>
         <header className='flex items-center justify-center gap-1.5 sm:gap-2 text-xl sm:text-2xl tracking-tighter'>
-          <h1>dolce</h1>
+          <h1>DOLCE</h1>
           <span aria-hidden>·</span>
-          <h2>the worldwide fashion database</h2>
+          <h2>The Worldwide Fashion Database</h2>
         </header>
         <Map className='w-full' />
       </section>


### PR DESCRIPTION
This patch updates the home page to include a meta title tag and proper title capitalization for the tag line text. I think this change makes the app feel more official: it mimics similar style on Vogue and Wikipedia ("The Free Encyclopedia").

Before:

![image](https://github.com/nicholaschiang/dolce/assets/20798889/a88f7f6d-47a4-4bae-ab93-f87d9d58e74f)

After:

![image](https://github.com/nicholaschiang/dolce/assets/20798889/361649ff-2b13-401b-b64c-19cae4563c18)