### PR TITLE
feat(routes/sets): link directly to set page

### DIFF
--- a/app/routes/_layout.sets.tsx
+++ b/app/routes/_layout.sets.tsx
@@ -27,7 +27,7 @@ export default function SetsPage() {
               <Link
                 prefetch='intent'
                 className='link underline'
-                to={`/${set.author.username}`}
+                to={`/${set.author.username}/sets/${set.id}`}
               >
                 {set.name} by @{set.author.username}
               </Link>


### PR DESCRIPTION
This patch updates the sets list to link directly to the sets page on the user's profile page instead of just the base user profile.