### PR TITLE
fix: only show filter options that have products

### DIFF
--- a/app/routes/_layout.brands.tsx
+++ b/app/routes/_layout.brands.tsx
@@ -10,7 +10,10 @@ import { log } from 'log.server'
 
 export async function loader() {
   log.debug('getting brands...')
-  const brands = await prisma.brand.findMany({ take: 100 })
+  const brands = await prisma.brand.findMany({
+    where: { products: { some: {} } },
+    take: 100,
+  })
   log.debug('got %d brands', brands.length)
   return brands
 }

--- a/app/routes/_layout.collections.tsx
+++ b/app/routes/_layout.collections.tsx
@@ -10,7 +10,10 @@ import { log } from 'log.server'
 
 export async function loader() {
   log.debug('getting collections...')
-  const collections = await prisma.collection.findMany({ take: 100 })
+  const collections = await prisma.collection.findMany({
+    where: { products: { some: {} } },
+    take: 100,
+  })
   log.debug('got %d collections', collections.length)
   return collections
 }

--- a/app/routes/_layout.designers.tsx
+++ b/app/routes/_layout.designers.tsx
@@ -11,13 +11,11 @@ import { log } from 'log.server'
 export async function loader() {
   log.debug('getting designers...')
   const designers = await prisma.user.findMany({
+    where: { products: { some: {} } },
     take: 100,
-    include: { _count: { select: { products: true } } },
   })
   log.debug('got %d designers', designers.length)
-  // TODO apply this filter at the database level instead of in JS.
-
-  return designers.filter((designer) => designer._count.products > 0)
+  return designers
 }
 
 export default function DesignersPage() {


### PR DESCRIPTION
This patch updates the collections page `loader` function to only fetch collections that have products. This should make both that page (where clicking on a collection opens the products list that are in said collection) and the products filtering drop-down make more sense.