### PR TITLE
perf(shows): remove unnecessary `collections` join

### DIFF
--- a/app/routes/_layout.shows._index.tsx
+++ b/app/routes/_layout.shows._index.tsx
@@ -70,7 +70,6 @@ export async function loader({ request }: LoaderArgs) {
       include: {
         season: true,
         brand: true,
-        collections: true,
         looks: {
           include: { images: { take: 1 } },
           orderBy: { number: 'asc' },


### PR DESCRIPTION
This patch removes an unnecessary `collections` SQL `JOIN` when selecting the shows list for the show search results page.