### PR TITLE
fix(scripts/save/shopify): log errors in one line

### DIFF
--- a/scripts/node/save/shopify.ts
+++ b/scripts/node/save/shopify.ts
@@ -110,10 +110,7 @@ export async function save() {
       await prisma.product.upsert(upsert)
       bar.tick()
     } catch (error) {
-      console.error(
-        `Error while saving product:`,
-        JSON.stringify(upsert, null, 2),
-      )
+      console.error(`Error while saving product:`, JSON.stringify(upsert))
       throw error
     }
   }


### PR DESCRIPTION
I was hitting the limit of my tmux scrollback and couldn't see the index that the error stopped at to restart the script there.