### PR TITLE
fix(app/infinite-list): add `initialRect` for SSR

### DIFF
--- a/app/components/infinite-list.tsx
+++ b/app/components/infinite-list.tsx
@@ -103,6 +103,7 @@ function InfiniteListContent<T>({
     lanes: itemsPerRow,
     overscan: 10,
     count: itemCount,
+    initialRect: { width: 0, height: 1000 },
   })
   useLayoutEffect(() => virtualizer.measure(), [itemHeight, virtualizer])
 


### PR DESCRIPTION
This patch updates the `useVirtualizer` call to specify an `initialRect` so that `getVirtualItems()` returns some items when server-side rendering. Previously, this was not a problem. It seems that updating some dependencies led to this becoming an issue.

Ref: https://github.com/TanStack/virtual/issues/218
Ref: https://github.com/TanStack/virtual/pull/217/commits/eb9a49017b00e849a482657caba81c2455a95a32

Fixes: 078af6fb017a ("build(deps): upgrade interactive all packages")