### PR TITLE
build(package.json): do not use prisma accelerate

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build:css": "pnpm generate:css --minify",
     "build:remix": "remix build",
     "build:server": "esbuild --platform=node --format=cjs ./server.ts --outdir=build --bundle",
-    "vercel-build": "replace 'prisma/client' 'prisma/client/edge' app -r && pnpm build",
     "dev": "run-p 'dev:*' | pino-pretty",
     "dev:prisma": "prisma generate --generator js --watch",
     "dev:build": "cross-env NODE_ENV=development pnpm build:server --watch",


### PR DESCRIPTION
This patch removes the `prisma/edge` use to instead just use Prisma normally and rely on Supabase's built-in transaction based connection pooling [[1]]. Prisma's free data proxy was shut down [[2]] and I do not want to have yet another product unnecessarily. I no longer deploy to edge functions [[3]], so the data proxy is unnecessary.

[1]: https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler
[2]: https://prismaio.notion.site/Migration-Guide-For-Data-Proxy-Users-Moving-to-Prisma-Accelerate-5df908648cf44a4f8fd4d2fe910e75e4
[3]: https://github.com/nicholaschiang/dolce/commit/3eb462751d59005c3de8eb57830ef121d25defc1