### PR TITLE
feat(app): add wardrobe panel open/close button

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -80,7 +80,7 @@ export function HeaderLink({ className, ...etc }: LinkProps) {
   )
 }
 
-export function HeaderActions() {
+export function HeaderActions({ children }: PropsWithChildren) {
   const matches = useMatches()
   const user = useOptionalUser()
   const isLoginPage = matches.some(
@@ -109,6 +109,7 @@ export function HeaderActions() {
         </Link>
       )}
       <ThemeSwitcher />
+      {children}
     </div>
   )
 }


### PR DESCRIPTION
This patch adds a button to toggle the wardrobe side-panel open and closed. This side-panel is not actually that useful in practice (as it is implemented right now), but I do not want to delete the code paths, as I do want a side-panel where users can save and curate what they're looking at to their profile (i.e. "their wardrobe").