### PR TITLE
fix(app/routes/brands): link to brand products

### DIFF
--- a/app/routes/_layout.brands.tsx
+++ b/app/routes/_layout.brands.tsx
@@ -24,10 +24,10 @@ export default function BrandsPage() {
   return (
     <ListLayout title='brands'>
       {brands.map((brand) => {
-        const param = filterToSearchParam<'brand', 'is'>({
+        const param = filterToSearchParam<'brands', 'some'>({
           id: nanoid(5),
-          name: 'brand',
-          condition: 'is',
+          name: 'brands',
+          condition: 'some',
           value: { id: brand.id, name: brand.name },
         })
         return (
@@ -35,7 +35,7 @@ export default function BrandsPage() {
             <Link
               prefetch='intent'
               className='link underline'
-              to={`/shows?${FILTER_PARAM}=${encodeURIComponent(param)}`}
+              to={`/products?${FILTER_PARAM}=${encodeURIComponent(param)}`}
             >
               {brand.name}
             </Link>


### PR DESCRIPTION
This patch links to the products page instead of the shows page when a user clicks on a brand link. We show all the products that have that brand. Previously, there were very few brands listed that had shows.